### PR TITLE
Checked Pinephone booting (Community Edition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Tow-boot images for the SPI flash for your board can be downloaded from [the pro
 This image has been tested to be working on the following devices:
 
 * Pine64-LTS (by Dan Johansen)
+* Pinephone Community Edition (by Benedikt Wildenhain)


### PR DESCRIPTION
I tried out Manjaro-ARM-kde-plasma-generic-20220606 on my Pinephone (Manjaro Community Edition) and it successfully booted.